### PR TITLE
Install & configure PHP Xdebug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,3 @@ BLACKFIRE_CLIENT_TOKEN=xxx
 BLACKFIRE_SERVER_ID=xxx
 BLACKFIRE_SERVER_TOKEN=xxx
 BLACKFIRE_LOG_LEVEL=4
-
-# If you're using PHP Xdebug insert your device's IP here
-XDEBUG_CONFIG=remote_host=127.0.0.1

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ BLACKFIRE_CLIENT_TOKEN=xxx
 BLACKFIRE_SERVER_ID=xxx
 BLACKFIRE_SERVER_TOKEN=xxx
 BLACKFIRE_LOG_LEVEL=4
+
+# If you're using PHP Xdebug insert your device's IP here
+XDEBUG_CONFIG=remote_host=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ You can connect to the MySQL server running in the container using [MySQL Workbe
 
 Alternatively you can add `127.0.0.1 mysql` to your hosts file so that the `mysql` hostname will work either from your host machine or from the docker containers (useful for CLI tools like Laravel's `artisan` command).
 
+### Xdebug
+
+To enable Xdebug for PHP you will need to edit `.env` and adjust `XDEBUG_CONFIG` to match your device's IP address. Do not use `localhost`, `127.0.0.1` or `::1` as your IP (as this will resolve to the Docker container, not your device). Next, rebuild the container(s) (eg. `docker-compose build php71-fpm && docker-compose up -d`).
+
+If you're using PHPStorm follow the [remote debug (docker) setup guide](https://www.jetbrains.com/help/phpstorm/configuring-remote-php-interpreters.html#d36845e650).
+
+The easiest way to trigger a debugging session is to use this [Google Chrome extension](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc). Just enable debug mode in the extension, set a breakpoint in the code and reload the page.
+
+If you're using Postman, cURL or another HTTP client simply send `XDEBUG_SESSION_START=session_name` as a GET or POST parameter.
+
 ### Redis
 You can connect to the Redis server with:
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,6 @@ Alternatively you can add `127.0.0.1 mysql` to your hosts file so that the `mysq
 
 ### Xdebug
 
-To enable Xdebug for PHP you will need to edit `.env` and adjust `XDEBUG_CONFIG` to match your device's IP address. Do not use `localhost`, `127.0.0.1` or `::1` as your IP (as this will resolve to the Docker container, not your device). Next, rebuild the container(s) (eg. `docker-compose build php71-fpm && docker-compose up -d`).
-
 If you're using PHPStorm follow the [remote debug (docker) setup guide](https://www.jetbrains.com/help/phpstorm/configuring-remote-php-interpreters.html#d36845e650).
 
 The easiest way to trigger a debugging session is to use this [Google Chrome extension](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc). Just enable debug mode in the extension, set a breakpoint in the code and reload the page.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ Alternatively you can add `127.0.0.1 mysql` to your hosts file so that the `mysq
 
 ### Xdebug
 
+> **NOTE**: This feature requires Docker 18.03 or later
+
+Xdebug has been installed and configured, but it's disabled by default as it makes everything run much slower!
+
+You can enable Xdebug as-needed by exec'ing into the desired PHP container, moving the Xdebug config file into place, and restarting that container:
+
+```
+docker-compose exec php71-fpm bash
+mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.DISABLE /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+docker-compose restart php71-fpm
+```
+
+To disable Xdebug again, simply reverse the process:
+
+```
+docker-compose exec php71-fpm bash
+mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.DISABLE
+docker-compose restart php71-fpm
+```
+
+Xdebug expects the debugging client (eg. PHPStorm) to be running on port `9000` of the Docker host machine.
+
 If you're using PHPStorm follow the [remote debug (docker) setup guide](https://www.jetbrains.com/help/phpstorm/configuring-remote-php-interpreters.html#d36845e650).
 
 The easiest way to trigger a debugging session is to use this [Google Chrome extension](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc). Just enable debug mode in the extension, set a breakpoint in the code and reload the page.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,8 @@ services:
     container_name: php71
     build: ./php71
     ports:
-      - "8080:8080"
-      - "3000:3000"
+      - "8080:8080" # Browser Sync
+      - "3000:3000" # Browser Sync
     restart: ${DOCKER_RESTART}
     volumes:
       - ${DOCUMENTROOT}:/var/www/html:delegated

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y \
         unzip \
         gnupg \
         --no-install-recommends \
-    && yes '' | pecl install -f memcache redis xdebug \
+    && yes '' | pecl install -f memcache redis xdebug-2.5.5 \
     && docker-php-ext-enable memcache redis xdebug \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) bcmath calendar gd intl mcrypt mysql mysqli opcache pdo_mysql soap xsl zip \

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -23,10 +23,11 @@ RUN apt-get update && apt-get install -y \
         unzip \
         gnupg \
         --no-install-recommends \
-    && yes '' | pecl install -f memcache redis \
-    && docker-php-ext-enable memcache redis \
+    && yes '' | pecl install -f memcache redis xdebug \
+    && docker-php-ext-enable memcache redis xdebug \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) calendar gd intl mcrypt mysql mysqli opcache pdo_mysql soap xsl zip bcmath \
+    && docker-php-ext-install -j$(nproc) bcmath calendar gd intl mcrypt mysql mysqli opcache pdo_mysql soap xsl zip \
+    && mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.DISABLE \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/php56/custom.ini
+++ b/php56/custom.ini
@@ -12,3 +12,9 @@ date.timezone = "Australia/Brisbane"
 
 [mail function]
 sendmail_path = "/usr/bin/mhsendmail --smtp-addr mailhog:1025"
+
+[xdebug]
+xdebug.profiler_enable_trigger = 1
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 0
+xdebug.remote_host = "host.docker.internal"

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -25,10 +25,11 @@ RUN apt-get update && apt-get install -y \
         net-tools \
         gnupg \
         --no-install-recommends \
-    && yes '' | pecl install -f redis \
-    && docker-php-ext-enable redis \
+    && yes '' | pecl install -f redis xdebug \
+    && docker-php-ext-enable redis xdebug \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) calendar gd intl mcrypt mysqli opcache pdo_mysql soap xsl zip bcmath mcrypt \
+    && docker-php-ext-install -j$(nproc) bcmath calendar gd intl mcrypt mysqli opcache pdo_mysql soap xsl zip \
+    && mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.DISABLE \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/php70/custom.ini
+++ b/php70/custom.ini
@@ -12,3 +12,9 @@ date.timezone = "Australia/Brisbane"
 
 [mail function]
 sendmail_path = "/usr/bin/mhsendmail --smtp-addr mailhog:1025"
+
+[xdebug]
+xdebug.profiler_enable_trigger = 1
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 0
+xdebug.remote_host = "host.docker.internal"

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update && apt-get install -y \
         net-tools \
         gnupg \
         --no-install-recommends \
-    && yes '' | pecl install -f redis \
-    && docker-php-ext-enable redis \
+    && yes '' | pecl install -f redis xdebug \
+    && docker-php-ext-enable redis xdebug \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) bcmath calendar gd intl mysqli opcache pdo_mysql soap xsl zip mcrypt \
     && apt-get clean \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && apt-get install -y \
     && yes '' | pecl install -f redis xdebug \
     && docker-php-ext-enable redis xdebug \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) bcmath calendar gd intl mysqli opcache pdo_mysql soap xsl zip mcrypt \
+    && docker-php-ext-install -j$(nproc) bcmath calendar gd intl mcrypt mysqli opcache pdo_mysql soap xsl zip \
+    && mv /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini.DISABLE \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/php71/custom.ini
+++ b/php71/custom.ini
@@ -14,7 +14,7 @@ date.timezone = "Australia/Brisbane"
 sendmail_path = "/usr/bin/mhsendmail --smtp-addr mailhog:1025"
 
 [xdebug]
-xdebug.default_enable = 0
+xdebug.profiler_enable_trigger = 1
 xdebug.remote_enable = 1
 xdebug.remote_autostart = 0
 xdebug.remote_host = "host.docker.internal"

--- a/php71/custom.ini
+++ b/php71/custom.ini
@@ -14,5 +14,7 @@ date.timezone = "Australia/Brisbane"
 sendmail_path = "/usr/bin/mhsendmail --smtp-addr mailhog:1025"
 
 [xdebug]
-xdebug.remote_enable = on
-xdebug.remote_autostart = off
+xdebug.default_enable = 0
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 0
+xdebug.remote_host = "host.docker.internal"

--- a/php71/custom.ini
+++ b/php71/custom.ini
@@ -12,3 +12,7 @@ date.timezone = "Australia/Brisbane"
 
 [mail function]
 sendmail_path = "/usr/bin/mhsendmail --smtp-addr mailhog:1025"
+
+[xdebug]
+xdebug.remote_enable = on
+xdebug.remote_autostart = off


### PR DESCRIPTION
This PR installs and configures Xdebug for PHP but leaves it in a disabled state by default (for performance reasons).

To enable and use Xdebug please see the instructions in the README.