### PR TITLE
Switch from MySQL 5.7 to MariaDB 10.2

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mariadb:10.2
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"


### PR DESCRIPTION
## Pros
There's a strong chance that if it's MySQL compatible, it will be MariaDB compatible also.

Our prod servers have been running MariaDB for nearly 2 years, and we'll likely upgrade to MariaDB 10.3 in the near future. So this proposed change will help bring our LDE tooling into line with them.

Also, it's difficult to install and run `mysqldump` in our PHP containers (eg. [Laravel Migration Squashing](https://laravel.com/docs/8.x/migrations#squashing-migrations)) because they're built on top of Debian Buster, which doesn't support MySQL (only MariaDB). It seems that the open source community is slowly shifting towards MariaDB.

## Cons
In my testing this seems to be somewhat of a drop-in replacement, but you might need to run:

1. `docker-compose exec mysql mysql_upgrade -p --force` (and enter your DB's root password at the prompt)
1. Truncate the MySQL general log: ``TRUNCATE TABLE `mysql`.`general_log`;``

As with any change there's a chance the upgrade could go wrong and LDE data could be lost.

## Discussion
Are there any other pros, cons or thoughts that we could consider?