### PR TITLE
Add support for arm64 (Apple Silicon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,24 +52,23 @@ The environment features clever *domain mapping* to allow you to run code for va
 
 * __http://classic-php.php56.{APACHE_HOSTNAME}__ (eg. http://classic-php.php56.localhost)
     * Will map to `~/Sites/classic-php` and use PHP 5.6
-* __http://laravel.php70.pub.{APACHE_HOSTNAME}__
-    * Will map to `~/Sites/laravel/public` and use PHP 7.0
-* __http://php-project.php80.{APACHE_HOSTNAME}__
-    * Will map to `~/Sites/php-project` and use PHP 8.0
+* __http://laravel.php74.pub.{APACHE_HOSTNAME}__
+    * Will map to `~/Sites/laravel/public` and use PHP 7.4
 * __http://another-project.{APACHE_HOSTNAME}__
-    * Will map to `~/Sites/another-project` and use the default version of PHP (currently 7.4)
+    * Will map to `~/Sites/another-project` and use the default version of PHP (currently 8.0)
 
 ---
 
 ## Prerequisites ⚠️
 
-* Your machine must be running MacOS, Windows 10 _Pro_ or Linux
-* Your CPU must support virtualisation (Intel VT-x or AMD-V)
-* You must have [Docker Compose](https://docs.docker.com/compose/install/) (version 1.25.0+) and Docker installed & running
+You'll first need to install Docker Desktop (or Docker on Linux).
+
 
 ---
 
 ## Installation 🚀
+
+> On Windows, we strongly recommend running these commands inside a WSL2 container for best performance
 
 ```bash
 # Clone the repo

--- a/php/56/Dockerfile
+++ b/php/56/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearepvtl/php-fpm-5.6:2
+FROM wearepvtl/php-fpm-5.6:latest
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"

--- a/php/70/Dockerfile
+++ b/php/70/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearepvtl/php-fpm-7.0:2
+FROM wearepvtl/php-fpm-7.0:latest
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"

--- a/php/71/Dockerfile
+++ b/php/71/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearepvtl/php-fpm-7.1:2
+FROM wearepvtl/php-fpm-7.1:latest
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"

--- a/php/72/Dockerfile
+++ b/php/72/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearepvtl/php-fpm-7.2:2
+FROM wearepvtl/php-fpm-7.2:latest
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"

--- a/php/73/Dockerfile
+++ b/php/73/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearepvtl/php-fpm-7.3:2
+FROM wearepvtl/php-fpm-7.3:latest
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"

--- a/php/74/Dockerfile
+++ b/php/74/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearepvtl/php-fpm-7.4:2
+FROM wearepvtl/php-fpm-7.4:latest
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"

--- a/php/80/Dockerfile
+++ b/php/80/Dockerfile
@@ -1,4 +1,4 @@
-FROM wearepvtl/php-fpm-8.0:2
+FROM wearepvtl/php-fpm-8.0:latest
 
 LABEL maintainer.name="Pivotal Agency" \
       maintainer.email="tech@pvtl.io"

--- a/php/src/README.md
+++ b/php/src/README.md
@@ -2,9 +2,19 @@
 
 This folder contains the PHP (only) Docker images that are pushed to Docker Hub.
 
-## What are these?
+The images are built for AMD64 (Intel) and ARM64 (Apple Silicon) CPU architectures.
 
-They are PHP images, customised to include features such as:
+
+## Why?
+
+Building the base PHP images takes a lot of time. Multiply that for each version of PHP you need. So it doesn't make sense that each end-user should need to do this.
+
+We're publishing pre-built images on the Docker Hub so users can simply pull and go. Users can still easily layer on any modifications as needed.
+
+
+## What's in these images?
+
+We use the [official PHP images](https://hub.docker.com/_/php) and add:
 
 - Helpful OS tools such as:
     - Git
@@ -26,51 +36,43 @@ They are PHP images, customised to include features such as:
 - PHPCS (PHP Latest)
 - Wordpress CLI (PHP Latest)
 
+
 ## How do I make updates?
 
-**1) Make the updates**
+**1) Edit the dockerfile**
 
-You'll notice in that `/php/*/Dockerfile`, that the first line says something like: `FROM wearepvtl/php-fpm-7.*`.
-This is saying that the LDE we build/run, is using the Pivotal PHP 7.* image.
+Each PHP version has it's own dockerfile (eg. `/php/80/Dockerfile` for PHP 8.0).
 
-Therefore, if you need to make a change (eg. add a new dependency), update the `/php/src/7*` image, build and push it to Docker Hub.
+Simply edit it and make the changes you need.
 
 **2) Distribute to Docker Hub**
 
-There are 2 ways to distribute the image/s to Docker Hub:
+Run the `/php/src/build-n-push.sh` script to manually build and push to Docker Hub. Automated builds aren't available at the moment.
 
-1. Automatically: Git tag a commit in the SemVer (eg. 2.5.3) format and Docker Hub will build and tag the new version to the major version
-    - eg. Git Tag `2.5.3` will build to Docker Tag `2` (which could then be used as `FROM wearepvtl/php-fpm-8.0:2` in a PHP 8.0 image example)
-2. Use the `/php/src/build-n-push.sh` script to manually build locally and push to Docker Hub
+Behind the scenes this script is building our PHP images for multiple platforms (AMD64 and ARM64).
+
+This script assumes the build process is being run on an ARM64 (Apple Silicon) CPU, and that a remote AMD64 (Intel) Docker instance is available to run the AMD64 build. You may need to adjust the script if you're running it on an AMD64 (Intel) device.
 
 **3) Make use of the new image**
 
-Once that's landed in Docker Hub, you'll be able to build/run your LDE again, which will pull the latest PHP 7.* image (the one you just updated).
+Once the images have landed in Docker Hub you'll be able to build/run a fresh version of your LDE (see instructions in the main README).
 
-## Why?
-
-This architecture allows us to more quickly and easily build and run LDEs, because the images are pre-built in Docker Hub. Therefore they only require that we download and run.
 
 ## Config & PHP.ini
 
 Each version of PHP shares the global config from `php/src/conf/custom.ini`. This config is baked into the Docker images we publish on Docker Hub.
 
-Those using the finished Docker images can override their PHP config in `php/conf/custom.ini`.
+Those using the published Docker images can override their PHP config in `php/conf/custom.ini`.
+
 
 ## Commands
 
-*Must be run from `/php/src/`
+> Must be run inside the `/php/src/` folder
 
 | Command | Description |
 | --- | --- |
-| `docker build -f 74/Dockerfile . -t wearepvtl/php-fpm-7.4` | Builds the PHP 7.4 image |
+| `docker build -f 80/Dockerfile . -t wearepvtl/php-fpm-8.0` | Builds the PHP 8.0 image |
 | `docker login --username=yourhubusername` | Login to Docker Hub |
-| `docker push wearepvtl/php-fpm-7.4` | Pushes the PHP 7.4 image to Docker Hub |
-| `docker run wearepvtl/php-fpm-7.4` | Opens the PHP 7.4 Container |
+| `docker push wearepvtl/php-fpm-8.0` | Pushes the PHP 8.0 image to Docker Hub |
+| `docker run wearepvtl/php-fpm-8.0` | Opens the PHP 8.0 Container |
 | `docker image prune -a` | Delete all images to start from scratch |
-
-## Build and push all
-
-This script will pull fresh copies of the official parent images and rebuild our Pivotal PHP images from scratch.
-
-`php/src/build-n-push.sh`

--- a/php/src/build-n-push.sh
+++ b/php/src/build-n-push.sh
@@ -4,6 +4,8 @@
 # Required by the relative paths below
 cd $(dirname "$0")
 
+
+# Decide on tagging
 echo -e "\n  ➤  Which tag would you like to push to? [default: latest]"
 read -p "== " TAG
 
@@ -11,64 +13,65 @@ if [[ -z "$TAG" ]]; then
   TAG="latest"
 fi
 
+
+# Setup build servers
+#   - arm64 is built locally on Apple Silicon
+#   - amd64 is built remotely on the dev server on x64/Intel hardware
+# (If your local machine is x64/Intel hardware then you can reverse these)
+docker buildx rm pvtl # Start from a clean slate
+docker buildx create --name pvtl --use
+docker buildx create --name pvtl --platform linux/amd64 --append ssh://pvtl@192.168.0.5 # Leverage the dev server
+
+
+# Let's start building!
+docker buildx build --pull -f 80/Dockerfile --platform linux/arm64,linux/amd64 -t wearepvtl/php-fpm-8.0:latest --push .
+
 if [[ ${TAG} != "latest" ]] ; then
-  echo -e "\n  ➤  Would you additionally like to push to 'latest' branch? [y/n]"
-  read -p "== " LATEST
-fi
-[ "$LATEST" != "${LATEST#[Yy]}" ] && LATEST=1 || LATEST=0
-
-docker build --pull -f 80/Dockerfile . -t wearepvtl/php-fpm-8.0
-docker tag wearepvtl/php-fpm-8.0 wearepvtl/php-fpm-8.0:${TAG}
-docker push wearepvtl/php-fpm-8.0:${TAG}
-
-if [[ ${LATEST} == 1 ]] ; then
-  docker push wearepvtl/php-fpm-8.0:latest
+  docker tag wearepvtl/php-fpm-8.0 wearepvtl/php-fpm-8.0:${TAG}
+  docker push wearepvtl/php-fpm-8.0:${TAG}
 fi
 
-docker build --pull -f 74/Dockerfile . -t wearepvtl/php-fpm-7.4
-docker tag wearepvtl/php-fpm-7.4 wearepvtl/php-fpm-7.4:${TAG}
-docker push wearepvtl/php-fpm-7.4:${TAG}
+docker buildx build --pull -f 74/Dockerfile --platform linux/arm64,linux/amd64 -t wearepvtl/php-fpm-7.4:latest --push .
 
-if [[ ${LATEST} == 1 ]] ; then
-  docker push wearepvtl/php-fpm-7.4:latest
+if [[ ${TAG} != "latest" ]] ; then
+  docker tag wearepvtl/php-fpm-7.4 wearepvtl/php-fpm-7.4:${TAG}
+  docker push wearepvtl/php-fpm-7.4:${TAG}
 fi
 
-docker build --pull -f 73/Dockerfile . -t wearepvtl/php-fpm-7.3
-docker tag wearepvtl/php-fpm-7.3 wearepvtl/php-fpm-7.3:${TAG}
-docker push wearepvtl/php-fpm-7.3:${TAG}
+docker buildx build --pull -f 73/Dockerfile --platform linux/arm64,linux/amd64 -t wearepvtl/php-fpm-7.3:latest --push .
 
-if [[ ${LATEST} == 1 ]] ; then
-  docker push wearepvtl/php-fpm-7.3:latest
+if [[ ${TAG} != "latest" ]] ; then
+  docker tag wearepvtl/php-fpm-7.3 wearepvtl/php-fpm-7.3:${TAG}
+  docker push wearepvtl/php-fpm-7.3:${TAG}
 fi
 
-docker build --pull -f 72/Dockerfile . -t wearepvtl/php-fpm-7.2
-docker tag wearepvtl/php-fpm-7.2 wearepvtl/php-fpm-7.2:${TAG}
-docker push wearepvtl/php-fpm-7.2:${TAG}
+docker buildx build --pull -f 72/Dockerfile --platform linux/arm64,linux/amd64 -t wearepvtl/php-fpm-7.2:latest --push .
 
-if [[ ${LATEST} == 1 ]] ; then
-  docker push wearepvtl/php-fpm-7.2:latest
+if [[ ${TAG} != "latest" ]] ; then
+  docker tag wearepvtl/php-fpm-7.2 wearepvtl/php-fpm-7.2:${TAG}
+  docker push wearepvtl/php-fpm-7.2:${TAG}
 fi
 
-docker build --pull -f 71/Dockerfile . -t wearepvtl/php-fpm-7.1
-docker tag wearepvtl/php-fpm-7.1 wearepvtl/php-fpm-7.1:${TAG}
-docker push wearepvtl/php-fpm-7.1:${TAG}
+docker buildx build --pull -f 71/Dockerfile --platform linux/arm64,linux/amd64 -t wearepvtl/php-fpm-7.1:latest --push .
 
-if [[ ${LATEST} == 1 ]] ; then
-  docker push wearepvtl/php-fpm-7.1:latest
+if [[ ${TAG} != "latest" ]] ; then
+  docker tag wearepvtl/php-fpm-7.1 wearepvtl/php-fpm-7.1:${TAG}
+  docker push wearepvtl/php-fpm-7.1:${TAG}
 fi
 
-docker build --pull -f 70/Dockerfile . -t wearepvtl/php-fpm-7.0
-docker tag wearepvtl/php-fpm-7.0 wearepvtl/php-fpm-7.0:${TAG}
-docker push wearepvtl/php-fpm-7.0:${TAG}
+docker buildx build --pull -f 70/Dockerfile --platform linux/arm64,linux/amd64 -t wearepvtl/php-fpm-7.0:latest --push .
 
-if [[ ${LATEST} == 1 ]] ; then
-  docker push wearepvtl/php-fpm-7.0:latest
+if [[ ${TAG} != "latest" ]] ; then
+  docker tag wearepvtl/php-fpm-7.0 wearepvtl/php-fpm-7.0:${TAG}
+  docker push wearepvtl/php-fpm-7.0:${TAG}
 fi
 
-docker build --pull -f 56/Dockerfile . -t wearepvtl/php-fpm-5.6
-docker tag wearepvtl/php-fpm-5.6 wearepvtl/php-fpm-5.6:${TAG}
-docker push wearepvtl/php-fpm-5.6:${TAG}
+docker buildx build --pull -f 56/Dockerfile --platform linux/arm64,linux/amd64 -t wearepvtl/php-fpm-5.6:latest --push .
 
-if [[ ${LATEST} == 1 ]] ; then
-  docker push wearepvtl/php-fpm-5.6:latest
+if [[ ${TAG} != "latest" ]] ; then
+  docker tag wearepvtl/php-fpm-5.6 wearepvtl/php-fpm-5.6:${TAG}
+  docker push wearepvtl/php-fpm-5.6:${TAG}
 fi
+
+# Tear down build servers
+docker buildx rm pvtl


### PR DESCRIPTION
Previously the images we published were AMD64 (Intel) only. This PR will make arm64 (Apple Silicon) images available so users can run them natively on supported platforms.